### PR TITLE
ActionDispatch::Executor don't fully trust `body#close`

### DIFF
--- a/actionpack/lib/action_dispatch/middleware/executor.rb
+++ b/actionpack/lib/action_dispatch/middleware/executor.rb
@@ -9,7 +9,7 @@ module ActionDispatch
     end
 
     def call(env)
-      state = @executor.run!
+      state = @executor.run!(reset: true)
       begin
         response = @app.call(env)
         returned = response << ::Rack::BodyProxy.new(response.pop) { state.complete! }

--- a/actionpack/test/dispatch/executor_test.rb
+++ b/actionpack/test/dispatch/executor_test.rb
@@ -119,6 +119,27 @@ class ExecutorTest < ActiveSupport::TestCase
     assert_not defined?(@in_shared_context) # it's not in the test itself
   end
 
+  def test_body_abandonned
+    total = 0
+    ran = 0
+    completed = 0
+
+    executor.to_run { total += 1; ran += 1 }
+    executor.to_complete { total += 1; completed += 1}
+
+    stack = middleware(proc { [200, {}, "response"] })
+
+    requests_count = 5
+
+    requests_count.times do
+      stack.call({})
+    end
+
+    assert_equal (requests_count * 2) - 1, total
+    assert_equal requests_count, ran
+    assert_equal requests_count - 1, completed
+  end
+
   private
     def call_and_return_body(&block)
       app = middleware(block || proc { [200, {}, "response"] })

--- a/activesupport/lib/active_support/execution_wrapper.rb
+++ b/activesupport/lib/active_support/execution_wrapper.rb
@@ -63,18 +63,21 @@ module ActiveSupport
     # after the work has been performed.
     #
     # Where possible, prefer +wrap+.
-    def self.run!
-      if active?
-        Null
+    def self.run!(reset: false)
+      if reset
+        lost_instance = active.delete(Thread.current)
+        lost_instance&.complete!
       else
-        new.tap do |instance|
-          success = nil
-          begin
-            instance.run!
-            success = true
-          ensure
-            instance.complete! unless success
-          end
+        return Null if active?
+      end
+
+      new.tap do |instance|
+        success = nil
+        begin
+          instance.run!
+          success = true
+        ensure
+          instance.complete! unless success
         end
       end
     end
@@ -103,11 +106,11 @@ module ActiveSupport
     self.active = Concurrent::Hash.new
 
     def self.active? # :nodoc:
-      @active[Thread.current]
+      @active.key?(Thread.current)
     end
 
     def run! # :nodoc:
-      self.class.active[Thread.current] = true
+      self.class.active[Thread.current] = self
       run_callbacks(:run)
     end
 

--- a/activesupport/lib/active_support/reloader.rb
+++ b/activesupport/lib/active_support/reloader.rb
@@ -58,7 +58,7 @@ module ActiveSupport
       prepare!
     end
 
-    def self.run! # :nodoc:
+    def self.run!(reset: false) # :nodoc:
       if check!
         super
       else


### PR DESCRIPTION
Under certain circumstances, the middleware isn't informed that the
response body has been fully closed which result in request state not
being fully reset before the next request.

[CVE-2022-23633]

Backported from the Rails 5.2 Patch

https://github.com/advisories/GHSA-wh98-p28r-vrc9