### PR TITLE
actionpack: Bump rack version

### DIFF
--- a/actionpack/actionpack.gemspec
+++ b/actionpack/actionpack.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport', version
 
-  s.add_dependency 'rack',      '~> 1.6'
-  s.add_dependency 'rack-test', '~> 0.6.2'
+  s.add_dependency 'rack',      '>= 2.0'
+  s.add_dependency 'rack-test', '>= 0.7.0'
   s.add_dependency 'rails-html-sanitizer', '~> 1.0', '>= 1.0.2'
   s.add_dependency 'rails-dom-testing', '~> 1.0', '>= 1.0.5'
   s.add_dependency 'actionview', version

--- a/actionpack/lib/action_dispatch/http/filter_parameters.rb
+++ b/actionpack/lib/action_dispatch/http/filter_parameters.rb
@@ -25,7 +25,7 @@ module ActionDispatch
       NULL_PARAM_FILTER = ParameterFilter.new # :nodoc:
       NULL_ENV_FILTER   = ParameterFilter.new ENV_MATCH # :nodoc:
 
-      def initialize(env)
+      def initialize
         super
         @filtered_parameters = nil
         @filtered_env        = nil

--- a/actionpack/lib/action_dispatch/http/request.rb
+++ b/actionpack/lib/action_dispatch/http/request.rb
@@ -13,12 +13,14 @@ require 'action_dispatch/http/url'
 require 'active_support/core_ext/array/conversions'
 
 module ActionDispatch
-  class Request < Rack::Request
+  class Request
+    include Rack::Request::Helpers
     include ActionDispatch::Http::Cache::Request
     include ActionDispatch::Http::MimeNegotiation
     include ActionDispatch::Http::Parameters
     include ActionDispatch::Http::FilterParameters
     include ActionDispatch::Http::URL
+    include Rack::Request::Env
 
     autoload :Session, 'action_dispatch/request/session'
     autoload :Utils,   'action_dispatch/request/utils'
@@ -333,11 +335,6 @@ module ActionDispatch
 
       Utils.deep_munge(hash)
     end
-
-    protected
-      def parse_query(qs)
-        Utils.deep_munge(super)
-      end
 
     private
       def check_method(name)

--- a/actionpack/lib/action_dispatch/http/url.rb
+++ b/actionpack/lib/action_dispatch/http/url.rb
@@ -166,7 +166,7 @@ module ActionDispatch
         end
       end
 
-      def initialize(env)
+      def initialize
         super
         @protocol = nil
         @port     = nil

--- a/actionpack/lib/action_dispatch/middleware/cookies.rb
+++ b/actionpack/lib/action_dispatch/middleware/cookies.rb
@@ -6,7 +6,7 @@ require 'active_support/message_verifier'
 require 'active_support/json'
 
 module ActionDispatch
-  class Request < Rack::Request
+  class Request
     def cookie_jar
       env['action_dispatch.cookies'] ||= Cookies::CookieJar.build(self)
     end

--- a/actionpack/lib/action_dispatch/middleware/flash.rb
+++ b/actionpack/lib/action_dispatch/middleware/flash.rb
@@ -1,7 +1,7 @@
 require 'active_support/core_ext/hash/keys'
 
 module ActionDispatch
-  class Request < Rack::Request
+  class Request
     # Access the contents of the flash. Use <tt>flash["notice"]</tt> to
     # read a notice you put there or <tt>flash["notice"] = "hello"</tt>
     # to put a new one.

--- a/actionpack/lib/action_dispatch/request/session.rb
+++ b/actionpack/lib/action_dispatch/request/session.rb
@@ -1,11 +1,11 @@
 require 'rack/session/abstract/id'
 
 module ActionDispatch
-  class Request < Rack::Request
+  class Request
     # Session is responsible for lazily loading the session from store.
     class Session # :nodoc:
-      ENV_SESSION_KEY         = Rack::Session::Abstract::ENV_SESSION_KEY # :nodoc:
-      ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY # :nodoc:
+      ENV_SESSION_KEY         = Rack::RACK_SESSION # :nodoc:
+      ENV_SESSION_OPTIONS_KEY = Rack::RACK_SESSION_OPTIONS # :nodoc:
 
       # Singleton object used to determine if an optional param wasn't specified
       Unspecified = Object.new

--- a/actionpack/lib/action_dispatch/request/utils.rb
+++ b/actionpack/lib/action_dispatch/request/utils.rb
@@ -1,5 +1,5 @@
 module ActionDispatch
-  class Request < Rack::Request
+  class Request
     class Utils # :nodoc:
 
       mattr_accessor :perform_deep_munge
@@ -32,4 +32,3 @@ module ActionDispatch
     end
   end
 end
-

--- a/actionpack/test/dispatch/request/session_test.rb
+++ b/actionpack/test/dispatch/request/session_test.rb
@@ -7,7 +7,7 @@ module ActionDispatch
       def test_create_adds_itself_to_env
         env = {}
         s = Session.create(store, env, {})
-        assert_equal s, env[Rack::Session::Abstract::ENV_SESSION_KEY]
+        assert_equal s, env[Rack::RACK_SESSION]
       end
 
       def test_to_hash


### PR DESCRIPTION
`rack` versions `< 2.2.3` have security vulnerabilities but `actionpack` pins the `rack` version to `~> 1.6`. Bumping `rack` brings a few minor but breaking changes which have been addressed upstream in `v5`. Those changes have been manually applied in the second commit here.

The changes in `actionpack` are from a combination of the following commits:
- 51211a94bd7a34d80f2412a7f94fefe7366647a5 - point at rack master
  - Rack constants were moved in v2
- 529136d670c46bd66b56c519d4f51ed8f86c75b1 - stop inheriting from Rack::Request
  - Rack request API changed in v2 so `actionpack` no longer inherits from the class, including the helpers instead
  - Including earlier changes to use `get_header` instead of `env` seemed excessive, so the rename to `fetch_header` is not applied here